### PR TITLE
using maths to generate a port number in to the data object so playwright can play right

### DIFF
--- a/.templates/app/package.json.hbs
+++ b/.templates/app/package.json.hbs
@@ -7,7 +7,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
-		"preview": "vite preview --port {{createPortNumber}}",
+		"preview": "vite preview --port {{pwPort}}",
 		"test": "npm run test:integration && npm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/.templates/app/playwright.config.ts.hbs
+++ b/.templates/app/playwright.config.ts.hbs
@@ -3,7 +3,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
 	webServer: {
 		command: 'npm run build && npm run preview',
-		port: 4173
+		port: {{pwPort}}
 	},
 	testDir: 'tests',
 	testMatch: /(.+\.)?(test|spec)\.[jt]s/

--- a/plopfile.mjs
+++ b/plopfile.mjs
@@ -22,10 +22,13 @@ export default function (
         type: 'addMany',
         destination: './apps/{{name}}',
         base: '.templates/app',
-        templateFiles: '.templates/app/**/*'
+        templateFiles: '.templates/app/**/*',
+        data: {
+          pwPort: Math.floor(Math.random() * 1000) + 4000
+        }
       },
       ({ name }) =>
-        `\n\n 🎉\n\n 🌟 ${name} app generated!\nIn order for Playwright to work you will need to grab the port assigned to preview job\nin apps/${name}/package.json and change it in the playwright.config.ts\n\nDon't forget to run pnpm install!\n\n 🎉\n\n`
+        `\n\n 🎉\n\n 🌟 ${name} app generated!\n\nDon't forget to run pnpm install!\n\n 🎉\n\n`
     ]
   });
 


### PR DESCRIPTION
Added `pwPort` as part of the actions data object so that it won't be random throughout the generation process, each instance should be unique but no need to manually copy a port number to a playwright.config.